### PR TITLE
Avoid rebuilding this package every time

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -7,5 +7,5 @@
    <maintainer>Malte Langosz/malte.langosz@dfki.de</maintainer>
    <depend package="osg" optional="1" />
    <depend package="qt4" optional="1" />
-    <tags>needs_opt</tags>
+    <tags>stable</tags>
 </package>


### PR DESCRIPTION
autoproj was setting CMAKE_BUILD_TYPE to RelWithDebInfo, and CMakeLists.txt set it back to Release every time.